### PR TITLE
IsParcel is redundant

### DIFF
--- a/activitystarter-parceler-arg-converter/src/main/java/com/marcinmoskala/activitystarterparcelerargconverter/IsParcel.java
+++ b/activitystarter-parceler-arg-converter/src/main/java/com/marcinmoskala/activitystarterparcelerargconverter/IsParcel.java
@@ -1,3 +1,0 @@
-package com.marcinmoskala.activitystarterparcelerargconverter;
-
-public interface IsParcel {}

--- a/activitystarter-parceler-arg-converter/src/main/java/com/marcinmoskala/activitystarterparcelerargconverter/ParcelarArgConverter.java
+++ b/activitystarter-parceler-arg-converter/src/main/java/com/marcinmoskala/activitystarterparcelerargconverter/ParcelarArgConverter.java
@@ -6,15 +6,15 @@ import org.parceler.Parcels;
 
 import activitystarter.wrapping.ArgConverter;
 
-public class ParcelarArgConverter implements ArgConverter<IsParcel, Parcelable> {
+public class ParcelarArgConverter implements ArgConverter<Object, Parcelable> {
 
     @Override
-    public Parcelable wrap(IsParcel toWrap) {
+    public Parcelable wrap(Object toWrap) {
         return Parcels.wrap(toWrap);
     }
 
     @Override
-    public IsParcel unwrap(Parcelable wrapped) {
+    public Object unwrap(Parcelable wrapped) {
         return Parcels.unwrap(wrapped);
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,8 @@ ext.deps = [
         javapoet          : 'com.squareup:javapoet:1.7.0',
         javaparser        : 'com.github.javaparser:javaparser-core:2.4.0',
         jodaTime          : 'joda-time:joda-time:2.9.3',
-        parceler          : 'org.parceler:parceler-api:1.1.6',
-        parceler_processor: 'org.parceler:parceler:1.1.6',
+        parceler          : 'org.parceler:parceler-api:1.1.8',
+        parceler_processor: 'org.parceler:parceler:1.1.8',
 
         // Test
         junit             : 'junit:junit:4.12',

--- a/sample/app/build.gradle
+++ b/sample/app/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.support:design:25.1.0'
 
-    compile 'org.parceler:parceler-api:1.1.6'
-    annotationProcessor 'org.parceler:parceler:1.1.6'
+    compile 'org.parceler:parceler-api:1.1.8'
+    annotationProcessor 'org.parceler:parceler:1.1.8'
 
     androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'

--- a/sample/app/src/main/java/com/example/activitystarter/parceler/StudentParceler.java
+++ b/sample/app/src/main/java/com/example/activitystarter/parceler/StudentParceler.java
@@ -1,18 +1,16 @@
 package com.example.activitystarter.parceler;
 
-import com.marcinmoskala.activitystarterparcelerargconverter.IsParcel;
+import org.parceler.Parcel;
+import org.parceler.ParcelConstructor;
 
-@org.parceler.Parcel
-public class StudentParceler implements IsParcel {
+@Parcel(Parcel.Serialization.BEAN)
+public class StudentParceler {
 
     private int id;
     private String name;
     private char grade;
 
-    public StudentParceler() {
-    }
-
-    // Constructor
+    @ParcelConstructor
     public StudentParceler(int id, String name, char grade) {
         this.id = id;
         this.name = name;


### PR DESCRIPTION
The marker interface `IsParcel` isn't necessary and is potentially misleading as part of the Parceler API.  This PR removed this interface and cleans up usage of Parceler.